### PR TITLE
User-definable list of small words.

### DIFF
--- a/tests/index.html
+++ b/tests/index.html
@@ -76,6 +76,22 @@
         }
       }
 
+      for (var i=0; i<testsTotal; i++) {
+        if (tests[i].input.toTitleCase('a', 'an', 'and', 'as', 'at', 'but',
+            'by', 'en', 'for', 'if', 'in', 'of', 'on', 'or', 'the', 'to',
+            'vs?\.?', 'via') !== tests[i].expects) {
+          print('Test ' + (i + 1) + ' failure:');
+          print(tab + 'inputed: ' + tests[i].input);
+          print(tab + 'expects: ' + tests[i].expects);
+          print(tab + 'returns: ' + tests[i].input.toTitleCase('a', 'an', 'and', 'as', 'at', 'but',
+          'by', 'en', 'for', 'if', 'in', 'of', 'on', 'or', 'the', 'to',
+          'vs?\.?', 'via'));
+
+          testsFailed++;
+        }
+      }
+      
+
       if (!testsFailed) {
         print('All tests passed.');
       }

--- a/to-title-case.js
+++ b/to-title-case.js
@@ -10,17 +10,9 @@ String.prototype.toTitleCase = function () {
 
   userWords = 1 <= arguments.length ? __slice.call(arguments, 0) : [];
 
-  if (userWords.length) {
-    var tmp = '^(';
-    for (i = 0; i < userwords.length) {
-      tmp += userWords[i];
-    }
-    tmp += ')$'
-    smallWords = new RegExp(tmp, 'i');
-    delete tmp;
+  if (userWords.length > 0) {
+    smallWords = new RegExp('^(' + userWords.join('|') + ')$' , 'i');
   }
-  delete userWords;
-  delete __slice;
 
   return this.replace(/([^\W_]+[^\s-]*) */g, function (match, p1, index, title) {
     if (index > 0 && index + p1.length !== title.length &&


### PR DESCRIPTION
Not sure if you'll want this commit or not, but this allows a user to pass in an argument for each word they'd like to be considered a "small word". If no words are passed in, the default list is used.

It doesn't expect a list passed in, instead, it reads all arguments individually. Then, it constructs a regex to match this list.
